### PR TITLE
feat: update action trigger

### DIFF
--- a/.github/workflows/generate-config.yaml
+++ b/.github/workflows/generate-config.yaml
@@ -1,8 +1,13 @@
 name: Update config
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+    
 
 jobs:
   update-config:


### PR DESCRIPTION
The previous version of action did not had access to the secrets and was failing to checkout the external repository.
We are using a new trigger that will allow access to secrets : https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
There is some security precautions to take when using that trigger, in our context the action will be triggered only if we merge the PR, that will consequently reduce security [concerns](https://stackoverflow.com/questions/78081249/github-actions-fails-to-access-secrets)