### PR TITLE
chore: fix token type

### DIFF
--- a/registry/mainnet/interchain/squid.tokenlist.json
+++ b/registry/mainnet/interchain/squid.tokenlist.json
@@ -2476,7 +2476,7 @@
       "prettySymbol": "CFG",
       "decimals": 18,
       "originAxelarChainId": "ethereum",
-      "tokenType": "custom",
+      "tokenType": "customInterchain",
       "deploySalt": "0x38a835532c2f53812b20282c76ce54b3af6ceed73b13eccd9bc21a3d52b7f9d4",
       "iconUrls": {
         "svg": "https://raw.githubusercontent.com/axelarnetwork/axelar-configs/main/images/tokens/cvg.svg"


### PR DESCRIPTION
fix token type for 0x526c3812e992e0a293ca6f7214f23625acb240e7132eb98e36c11d1428f5a961. this should have been caught in our basic checks. we'll follow up with a fix for that after