### PR TITLE
feat: add mXRP binance

### DIFF
--- a/registry/mainnet/interchain/squid.tokenlist.json
+++ b/registry/mainnet/interchain/squid.tokenlist.json
@@ -6321,6 +6321,39 @@
         }
       ]
     },
+    "0x18094f558f8d711e1386b0fdbce61ee57373cf5b31ec69223b87147518eb73d4": {
+      "tokenId": "0x18094f558f8d711e1386b0fdbce61ee57373cf5b31ec69223b87147518eb73d4",
+      "deployer": "0xcB593eD9bCca69f186dA2affC60e29D7BDf967FE",
+      "originalMinter": null,
+      "prettySymbol": "mXRP",
+      "decimals": 18,
+      "originAxelarChainId": "xrpl-evm",
+      "tokenType": "canonical",
+      "deploySalt": "0x56a4be9f94bd303603f318af6efeca4dac599b3a9a339208c54723ddd701c063",
+      "coinGeckoId": "midas-xrp",
+      "iconUrls": {
+        "svg": "https://raw.githubusercontent.com/axelarnetwork/axelar-configs/main/images/tokens/mxrp.svg"
+      },
+      "deploymentMessageId": "0xc367e6625381f31c3e27eefa632251265865d09e6477f0f07b3bdd744ed0643c-3",
+      "chains": [
+        {
+          "symbol": "mXRP",
+          "name": "Midas XRP",
+          "axelarChainId": "xrpl-evm",
+          "tokenAddress": "0x06e0B0F1A644Bb9881f675Ef266CeC15a63a3d47",
+          "tokenManager": "0xD0F79e5Db4dfFe7F3e372604f46189a54a3EeeaC",
+          "tokenManagerType": "lockUnlock"
+        },
+        {
+          "symbol": "mXRP",
+          "name": "Midas XRP",
+          "axelarChainId": "binance",
+          "tokenAddress": "0xc8739fbBd54C587a2ad43b50CbcC30ae34FE9e34",
+          "tokenManager": "0xA16024Ebc6FC450f57C63fCe1E4CE446Bf1CfE6d",
+          "tokenManagerType": "mintBurn"
+        }
+      ]
+    },
     "0xedb4e6c60750463f5e3970bd7bdbf4af48ffdcb8ac4e40b680e491ca338dd1ba": {
       "tokenId": "0xedb4e6c60750463f5e3970bd7bdbf4af48ffdcb8ac4e40b680e491ca338dd1ba",
       "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",

--- a/registry/mainnet/interchain/squid.tokenlist.json
+++ b/registry/mainnet/interchain/squid.tokenlist.json
@@ -6297,7 +6297,7 @@
       "originAxelarChainId": "xrpl-evm",
       "tokenType": "canonical",
       "deploySalt": "0x",
-      "coinGeckoId": "xrp",
+      "coinGeckoId": "midas-xrp",
       "iconUrls": {
         "svg": "https://raw.githubusercontent.com/axelarnetwork/axelar-configs/main/images/tokens/mxrp.svg"
       },
@@ -6341,7 +6341,7 @@
           "name": "Midas XRP",
           "axelarChainId": "xrpl-evm",
           "tokenAddress": "0x06e0B0F1A644Bb9881f675Ef266CeC15a63a3d47",
-          "tokenManager": "0xD0F79e5Db4dfFe7F3e372604f46189a54a3EeeaC",
+          "tokenManager": "0xA16024Ebc6FC450f57C63fCe1E4CE446Bf1CfE6d",
           "tokenManagerType": "lockUnlock"
         },
         {


### PR DESCRIPTION
Add the correct route `xrpl-evm` <-> `binance` for mXRP, whose incorrect route was removed in #350 .

RegisterTokenMetadata tx: https://explorer.xrplevm.org/tx/0x0665782d0e51cb19656bba70565696482917343446b6e09617f7866d013a6311?tab=logs
RegisterCustomToken tx: https://explorer.xrplevm.org/tx/0x1f1d671ca8670212258e496e29e78b8c9c2cc503b2ec50cdce74c568d441b1e7?tab=logs
LinkToken source tx: https://explorer.xrplevm.org/tx/0xc367e6625381f31c3e27eefa632251265865d09e6477f0f07b3bdd744ed0643c?tab=logs
LinkToken GMP call: https://axelarscan.io/gmp/0xc367e6625381f31c3e27eefa632251265865d09e6477f0f07b3bdd744ed0643c-3

Test: On https://github.com/axelarnetwork/axelar-contract-deployments (#f3e620a0) run:
```ENV=mainnet ts-node evm/its.js interchain-transfer --destinationChain binance --tokenId 0x18094f558f8d711e1386b0fdbce61ee57373cf5b31ec69223b87147518eb73d4 --destinationAddress $ADDRESS --amount 0.000001 -n xrpl-evm -p $PRIVATE_KEY```
This results in a successful [ITS transfer](https://axelarscan.io/gmp/0xe678be6713b83e3ad268bd701f9c19985cb6676a1ef4d6509c5843c73cb6964e-3) which was successfully executed causing [funds to have been minted on binance](https://bscscan.com/token/0xc8739fbbd54c587a2ad43b50cbcc30ae34fe9e34?a=0x72D489FC91F33011EC46EFA78D37E02DCC335453).

mXRP on coingecko: https://www.coingecko.com/en/coins/midas-xrp