### PR TITLE
chore: add test token solana <-> xrpl-evm

### DIFF
--- a/images/tokens/test.svg
+++ b/images/tokens/test.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg fill="#000000" version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 403.48 403.48" xml:space="preserve">
+<g>
+	<path d="M277.271,0H46.176v403.48h311.129V80.035L277.271,0z M281.664,25.607l50.033,50.034h-50.033V25.607z M61.176,388.48V15
+		h205.489v75.641h75.641v297.84H61.176z"/>
+	<path d="M101.439,117.58h55.18V62.4h-55.18V117.58z M116.439,77.4h25.18v25.18h-25.18V77.4z"/>
+	<path d="M101.439,192.08h55.18V136.9h-55.18V192.08z M116.439,151.9h25.18v25.18h-25.18V151.9z"/>
+	<path d="M101.439,266.581h55.18V211.4h-55.18V266.581z M116.439,226.4h25.18v25.181h-25.18V226.4z"/>
+	<path d="M101.439,341.081h55.18v-55.18h-55.18V341.081z M116.439,300.901h25.18v25.18h-25.18V300.901z"/>
+	<rect x="177.835" y="326.081" width="114.688" height="15"/>
+	<rect x="177.835" y="251.581" width="114.688" height="15"/>
+	<rect x="177.835" y="177.08" width="114.688" height="15"/>
+	<rect x="177.835" y="102.58" width="114.688" height="15"/>
+</g>
+</svg>

--- a/registry/mainnet/interchain/squid.tokenlist.json
+++ b/registry/mainnet/interchain/squid.tokenlist.json
@@ -6847,6 +6847,39 @@
       ],
       "coinGeckoId": ""
     },
+    "0xe13b0021295b56283cef538a4d0efb950900e403bcdd0573077f758dbc1b3c0a": {
+      "tokenId": "0xe13b0021295b56283cef538a4d0efb950900e403bcdd0573077f758dbc1b3c0a",
+      "deployer": "0x72D489FC91f33011EC46Efa78d37E02dCC335453",
+      "originalMinter": "0x72D489FC91f33011EC46Efa78d37E02dCC335453",
+      "prettySymbol": "DT0",
+      "decimals": 18,
+      "originAxelarChainId": "xrpl-evm",
+      "tokenType": "interchain",
+      "deploySalt": "0xfffa644fc96e24eed30e3af669aa1f0201058f897970bfda8493c17c4f31d96e",
+      "coinGeckoId": "",
+      "iconUrls": {
+        "svg": "https://raw.githubusercontent.com/axelarnetwork/axelar-configs/main/images/tokens/test.svg"
+      },
+      "deploymentMessageId": "",
+      "chains": [
+        {
+          "symbol": "DT0",
+          "name": "Test token DT0",
+          "axelarChainId": "xrpl-evm",
+          "tokenAddress": "0x8616fCe6c7E066A9f87A4e2779e1651Ea1a43FFC",
+          "tokenManager": "0x1FDB9eDD2BBd72dBd9d0287468A583Dc43e5bCF7",
+          "tokenManagerType": "lockUnlock"
+        },
+        {
+          "symbol": "DT0",
+          "name": "Test token DT0",
+          "axelarChainId": "solana",
+          "tokenAddress": "FgNuB1BWH4KPshxGd9Pae5dg6EJVax8wH6912yMysU9v",
+          "tokenManager": "B6WAYnLVt5g5M36UdEEWMqrvFoCYgWL5uNKVVnXcJk9b",
+          "tokenManagerType": "mintBurn"
+        }
+      ]
+    },
     "0xf53b874caa6c232f9660ba5d1262c5fe6ec366f2dcf2f94ac9057faba8098695": {
       "tokenId": "0xf53b874caa6c232f9660ba5d1262c5fe6ec366f2dcf2f94ac9057faba8098695",
       "deployer": "0x70cAa113fF29D1E3F7a49d3a0fc8D3184F83Db63",


### PR DESCRIPTION
This PR adds a test token (DT0) to allow testing the route Solana <-> EVM. The `coinGeckoIs` is left intentionally blank, which allegedly prevents this from being displayed on Squid's production environment. 
Relevant deployment: https://axelarscan.io/gmp/0xe84bf6655c05fd6352fd51cbcdbe576e611bec812302a5e52066bbd97017e525-3 