### PR TITLE
feat: add tokenProgramId to tokenlist

### DIFF
--- a/cli/schemas/interchain-tokenlist.ts
+++ b/cli/schemas/interchain-tokenlist.ts
@@ -10,6 +10,13 @@ export const chains = z.object({
   tokenAddress: address,
   tokenManager: address,
   tokenManagerType: z.string(),
+  tokenProgramId: z
+    .enum([
+      // required for Solana tokens
+      "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb", // Token-2022 (default for tokens deployed through ITS)
+      "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA", // Token Program
+    ])
+    .optional(),
   decimals: z.number().int().optional(),
   symbol: z.string(),
   name: z.string(),

--- a/registry/mainnet/interchain/squid.tokenlist.json
+++ b/registry/mainnet/interchain/squid.tokenlist.json
@@ -6909,7 +6909,8 @@
           "axelarChainId": "solana",
           "tokenAddress": "FgNuB1BWH4KPshxGd9Pae5dg6EJVax8wH6912yMysU9v",
           "tokenManager": "B6WAYnLVt5g5M36UdEEWMqrvFoCYgWL5uNKVVnXcJk9b",
-          "tokenManagerType": "mintBurn"
+          "tokenManagerType": "mintBurn",
+          "tokenProgramId": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
         }
       ]
     },

--- a/registry/schemas/cosmos-chains.schema.json
+++ b/registry/schemas/cosmos-chains.schema.json
@@ -168,6 +168,11 @@
                   ]
                 },
                 "description": "List of features supported by the chain"
+              },
+              "deprecated": {
+                "type": "boolean",
+                "default": false,
+                "description": "This chain is scheduled to be deprecated"
               }
             },
             "required": [

--- a/registry/schemas/evm-chains.schema.json
+++ b/registry/schemas/evm-chains.schema.json
@@ -73,6 +73,11 @@
                 "type": "string",
                 "pattern": "\\/images\\/chains\\/([a-z\\-]+)\\.svg$",
                 "description": "the icon for the chain, must be a relative path to a svg icon under /images/chains"
+              },
+              "deprecated": {
+                "type": "boolean",
+                "default": false,
+                "description": "This chain is scheduled to be deprecated"
               }
             },
             "required": [

--- a/registry/schemas/interchain-tokenlist.schema.json
+++ b/registry/schemas/interchain-tokenlist.schema.json
@@ -32,13 +32,13 @@
           "$ref": "#/definitions/chains/properties/tokenAddress"
         },
         "tokenManagerType": { "type": "string" },
+        "decimals": { "type": "integer" },
         "symbol": { "type": "string" },
         "name": { "type": "string" },
-        "decimals": { "type": "integer" },
         "deprecated": {
           "type": "boolean",
           "default": false,
-          "description": "This token on this chain is scheduled to be deprecated"
+          "description": "The token on this chain is scheduled to be deprecated"
         }
       },
       "required": [
@@ -56,12 +56,7 @@
       "properties": {
         "tokenId": { "type": "string", "pattern": "^0x[a-fA-F0-9]{64}$" },
         "deployer": { "$ref": "#/definitions/chains/properties/tokenAddress" },
-        "originalMinter": {
-          "anyOf": [
-            { "$ref": "#/definitions/chains/properties/tokenAddress" },
-            { "type": "null" }
-          ]
-        },
+        "originalMinter": { "type": ["string", "null"] },
         "prettySymbol": { "type": "string" },
         "decimals": { "type": "integer" },
         "originAxelarChainId": { "type": "string" },

--- a/registry/schemas/interchain-tokenlist.schema.json
+++ b/registry/schemas/interchain-tokenlist.schema.json
@@ -32,6 +32,13 @@
           "$ref": "#/definitions/chains/properties/tokenAddress"
         },
         "tokenManagerType": { "type": "string" },
+        "tokenProgramId": {
+          "type": "string",
+          "enum": [
+            "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+            "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+          ]
+        },
         "decimals": { "type": "integer" },
         "symbol": { "type": "string" },
         "name": { "type": "string" },


### PR DESCRIPTION
Solana ITS supports two different token standards ("Token Program" and "Token-2022"). This PR adds a config field `tokenProgramId` to chain entries in the tokenlist.
Previous changes apparently did not run codegen, which is why there are unrelated changes in the generated files.